### PR TITLE
Fix static call of non-static function deprecated in php 7

### DIFF
--- a/Classes/BemHelper.php
+++ b/Classes/BemHelper.php
@@ -23,7 +23,7 @@ class BemHelper implements ProtectedContextAwareInterface
      */
     public function string($block = null, $element = null, $modifiers = []): string
     {
-        return StringHelper::BEM($block, $element, $modifiers);
+        return (new StringHelper())->BEM($block, $element, $modifiers);
     }
 
     /**
@@ -36,7 +36,7 @@ class BemHelper implements ProtectedContextAwareInterface
      */
     public function modifier($class = null, $modifiers = []): string
     {
-        return StringHelper::BEM($class, null, $modifiers);
+        return (new StringHelper())->BEM($class, null, $modifiers);
     }
 
     /**
@@ -50,7 +50,7 @@ class BemHelper implements ProtectedContextAwareInterface
      */
     public function array($block = null, $element = null, $modifiers = []): string
     {
-        return ArrayHelper::BEM($block, $element, $modifiers);
+        return (new ArrayHelper())->BEM($block, $element, $modifiers);
     }
 
     /**

--- a/Classes/StringHelper.php
+++ b/Classes/StringHelper.php
@@ -24,7 +24,7 @@ class StringHelper implements ProtectedContextAwareInterface
      */
     public function BEM($block = null, $element = null, $modifiers = []): string
     {
-        return implode(" ", ArrayHelper::BEM($block, $element, $modifiers));
+        return implode(" ", (new ArrayHelper())->BEM($block, $element, $modifiers));
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,11 @@
     "description": "Some nice Eel helper for Neos.io",
     "license": "MIT",
     "keywords": ["neos", "fusion", "helper", "eel", "carbon"],
+    "config": {
+        "platform": {
+            "php": "^7.0"
+        }
+    },
     "require": {
         "neos/flow": "~4.0 || ~5.0 || ~6.0",
         "behat/transliterator": "^1.2"


### PR DESCRIPTION
As of PHP 7 the calling of non-static as static has been deprecated, the deprecation notice can be found at https://www.php.net/manual/en/language.oop5.static.php#language.oop5.static.methods

In this fix I resolve this issue and add the PHP 7 platform requirement which is implied by the use of other php 7 features such as the use of return types.