### PR TITLE
Breaking: Remove deprecated functions

### DIFF
--- a/Classes/EelHelper/ArrayHelper.php
+++ b/Classes/EelHelper/ArrayHelper.php
@@ -51,24 +51,6 @@ class ArrayHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Adds a key / value pair to an array
-     *
-     * @param iterable $array The array
-     * @param string $key The target key
-     * @param mixed $value The value
-     * @return array
-     * @deprecated Will be removed in version 2. Use Array.key() instead.
-     */
-    public function setKeyValue(iterable $array, string $key, $value): array
-    {
-        if ($array instanceof Traversable) {
-            $array = iterator_to_array($array);
-        }
-        $array[$key] = $value;
-        return $array;
-    }
-
-    /**
      * Split an array into chunks
      *
      * Chunks an array into arrays with length elements.
@@ -185,52 +167,6 @@ class ArrayHelper implements ProtectedContextAwareInterface
     public function setValueByPath($subject, $path, $value)
     {
         return Arrays::setValueByPath($subject, $path, $value);
-    }
-
-    /**
-     * Sort an array by key
-     *
-     * @param iterable $array The array to sort
-     * @return array
-     * @deprecated Will be removed in version 2. Use Array.ksort() instead.
-     */
-    public function ksort(iterable $array): array
-    {
-        if ($array instanceof Traversable) {
-            $array = iterator_to_array($array);
-        }
-        ksort($array, SORT_NATURAL | SORT_FLAG_CASE);
-        return $array;
-    }
-
-    /**
-     * PHPs array_filter
-     *
-     * @param iterable $array The array to filter
-     * @return array
-     * @deprecated Will be removed in version 2. Use Array.filter() instead.
-     */
-    public function filter(iterable $array): array
-    {
-        if ($array instanceof Traversable) {
-            $array = iterator_to_array($array);
-        }
-        return array_filter($array);
-    }
-
-    /**
-     * Return all the values of an array
-     *
-     * @param iterable $array The array
-     * @return array Returns an indexed array of values
-     * @deprecated Will be removed in version 2. Use Array.values() instead.
-     */
-    public function values(iterable $array): array
-    {
-        if ($array instanceof Traversable) {
-            $array = iterator_to_array($array);
-        }
-        return array_values($array);
     }
 
     /**

--- a/Classes/EelHelper/StringHelper.php
+++ b/Classes/EelHelper/StringHelper.php
@@ -82,31 +82,6 @@ class StringHelper implements ProtectedContextAwareInterface
     }
 
     /**
-     * Replace occurrences of a search string inside the string using regular expression matching (PREG style)
-     *
-     * Examples::
-     *
-     *     Carbon.String.pregReplace("Some.String with sp:cial characters", "/[[:^alnum:]]/", "-") == "Some-String-with-sp-cial-characters"
-     *     Carbon.String.pregReplace("2016-08-31", "/([0-9]+)-([0-9]+)-([0-9]+)/", "$3.$2.$1") == "31.08.2016"
-     *
-     * @param string $string The input string
-     * @param string $pattern A PREG pattern
-     * @param string $replace A replacement string, can contain references to capture groups with "\\n" or "$n"
-     * @param integer $limit The maximum possible replacements for each pattern in each subject string. Defaults to -1 (no limit).
-     * @return string The string with all occurrences replaced
-     * @deprecated Will be removed in version 2. Use String.pregReplace() instead.
-     */
-
-    public function pregReplace(
-        string $string,
-        string $pattern,
-        string $replace,
-        int $limit = -1
-    ): string {
-        return preg_replace($pattern, $replace, (string) $string, $limit);
-    }
-
-    /**
      * Helper to convert `CamelCaseStrings` to `hyphen-case-strings`
      *
      * Examples:

--- a/README.md
+++ b/README.md
@@ -47,73 +47,6 @@ Chunks an array into arrays with `length` elements. The last chunk may contain l
 -   `length` (integer, required) The size of each chunk
 -   `preserveKeys` (bool) When set to `true`, keys will be preserved. Default is `false`, which will reindex the chunk numerically
 
-### `Carbon.Array.setKeyValue(array, key, value)`
-
-> **Deprecated** Will be removed in version 2. Use `Array.key()` instead.
-
-It can be used to add a value with a dynamic key.
-
-Example:
-
-```elm
-array = Neos.Fusion:RawArray
-array.@process.addKeyValue = ${Carbon.Array.setKeyValue(value, 'key', 'value')}
-```
-
--   `array` (array) The array which should be extended
--   `key` (string) The key for the entry
--   `value` (mixed) The value
-
-**Return** The extended array
-
-### `Carbon.Array.ksort(array)`
-
-> **Deprecated** Will be removed in version 2. Use `Array.ksort()` instead.
-
-Sort an array by key
-
-Example:
-
-```elm
-array.@process.ksort = ${Carbon.Array.ksort(value)}
-```
-
--   `array` (array) The array which should be sorted
-
-**Return** The sorted array
-
-### `Carbon.Array.filter(array)`
-
-> **Deprecated** Will be removed in version 2. Use `Array.filter()` instead.
-
-Iterates over each value in the array, and all entries of the array equal to `false` will be removed.
-
-Example:
-
-```elm
-array.@process.filter = ${Carbon.Array.filter(value)}
-```
-
--   `array` (array) The array to iterate over
-
-**Return** The filtered array
-
-### `Carbon.Array.values(array)`
-
-> **Deprecated** Will be removed in version 2. Use `Array.values()` instead.
-
-Return all the values of an array
-
-Example:
-
-```elm
-array.@process.values = ${Carbon.Array.values(value)}
-```
-
--   `array` (array) The array to convert
-
-**Return** An indexed array of values.
-
 ### `Carbon.Array.join(array, separator)`
 
 Join the given array recursively using the given separator.
@@ -443,19 +376,6 @@ Carbon.String.removeNbsp('hello   world') == 'hello world'
 -   `string` (string) A string to convert
 
 **Return** The converted string
-
-### `Carbon.String.pregReplace(string, pattern, replace, limit)`
-
-> **Deprecated** Will be removed in version 2. Use `String.pregReplace()` instead.
-
-Replace occurrences of a search string inside the string using regular expression matching (PREG style).
-
--   `string` (string) The input string
--   `pattern` (string) A PREG pattern
--   `replace` (string) A replacement string, can contain references to capture groups with "\\n" or "\$n"
--   `limit` (integer) The maximum possible replacements for each pattern in each subject string. Defaults to -1 (no limit).
-
-**Return** The string with all occurrences replaced
 
 ### `Carbon.String.merge(mixed1, mixed2, mixedN)`
 


### PR DESCRIPTION
| Removed | Replacement from Neos.Eel |
| - | - |
| `Carbon.Array.setKeyValue()` | `Array.set()` |
| `Carbon.Array.ksort()` | `Array.ksort()` |
| `Carbon.Array.filter()` | `Array.filter()` |
| `Carbon.Array.values()` | `Array.values()` |
| `Carbon.String.pregReplace()` | `String.pregReplace()` |